### PR TITLE
Fixed compatibility with Windows

### DIFF
--- a/lib/vagrant-foodshow/action/stop.rb
+++ b/lib/vagrant-foodshow/action/stop.rb
@@ -1,3 +1,5 @@
+require 'vagrant/util/platform'
+
 module VagrantPlugins
   module Foodshow
     module Action
@@ -13,7 +15,9 @@ module VagrantPlugins
             ::File.open(pid_file, 'r') do |f|
               begin
                 pid = f.readline().to_i
-                ::Process.kill('TERM', pid)
+                f.close
+                sigterm = Vagrant::Util::Platform.windows? ? 'KILL' : 'TERM'
+                ::Process.kill(sigterm, pid)
                 ::File.delete(pid_file)
               rescue Errno::ESRCH
                 ::File.delete(pid_file)

--- a/lib/vagrant-foodshow/util/ngrok.rb
+++ b/lib/vagrant-foodshow/util/ngrok.rb
@@ -2,6 +2,7 @@ require 'json'
 require 'open3'
 require 'timeout'
 require 'vagrant-foodshow/util/ngrok_config.rb'
+require 'vagrant/util/platform'
 
 module VagrantPlugins
   module Foodshow
@@ -85,7 +86,8 @@ module VagrantPlugins
           unless status == 0
             begin
               ::File.delete(pid_file)
-              ::Process.kill('TERM', pid)
+              sigterm = Vagrant::Util::Platform.windows? ? 'KILL' : 'TERM'
+              ::Process.kill(sigterm, pid)
             rescue
               # ignored
             end


### PR DESCRIPTION
- pid-file cannot be deleted while it is opened
- only KILL signal allowed on Windows